### PR TITLE
[WEB-61] Update Co-badge list

### DIFF
--- a/_data/cobadge-highlight.yaml
+++ b/_data/cobadge-highlight.yaml
@@ -1,5 +1,5 @@
 it:
-  last_update: 06/04/2021
+  last_update: 29/04/2021
   items:
     # use alphabetical order
     - name: Banca Sella
@@ -20,15 +20,15 @@ it:
     - name: Gruppo ICCREA
       img: /assets/img/cashback/issuer/gbci.png
       onlylogo: true
+    - name: Intesa Sanpaolo
+      img: /assets/img/cashback/issuer/intesa.png
+      onlylogo: true
     - name: UBI Banca
       img: /assets/img/cashback/issuer/ubi.png
       onlylogo: true
     - name: UniCredit
       img: /assets/img/cashback/issuer/unicredit.png
       onlylogo: true
-    - name: Intesa Sanpaolo
-      img: /assets/img/cashback/issuer/intesa.png
-      # va mostrato 'in arrivo'
     - name: Poste Italiane
       img: /assets/img/cashback/issuer/poste.png
       # va mostrato 'in arrivo'


### PR DESCRIPTION
This PR adds Intesa Sanpaolo to the banks supported by the co-badge service.