### PR TITLE
[WEB-137] Home update

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -23,7 +23,9 @@ layout: default
 {%- include home/italia.html -%}
 
 {%- include home/section-2.html -%}
+
 {%- include home/section-3.html -%}
+
 {%- include home/section-4.html -%}
 
 {%- include home/section-7.html -%}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -14,7 +14,6 @@ layout: default
 
 {%- include home/section-14.html -%}
 
-{%- include home/section-cashback.html -%}
 {%- include home/section-bonus.html -%}
 
 {%- include home/device.html -%}


### PR DESCRIPTION
This PR removes Cashback module from the Home Page. The landing content is still reachable from the top menu