### PR TITLE
[#WEB-208] Split deploy for Enti&Servizi and other

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -15,20 +15,13 @@ parameters:
 # $(MY_INDEX)
 # $(BLOB_CONTAINER_NAME)
 variables:
-  ${{ if eq(parameters['environment'], 'dev') }}:
-    AZURE_SUBSCRIPTION: $(DEV_AZURE_SUBSCRIPTION)
-    STORAGE_ACCOUNT_NAME: $(DEV_STORAGE_ACCOUNT_NAME)
-    PROFILE_CDN_NAME: $(DEV_PROFILE_CDN_NAME)
-    ENDPOINT_NAME: $(DEV_ENDPOINT_NAME)
-    RESOURCE_GROUP_NAME: $(DEV_RESOURCE_GROUP_NAME)
-    JEKYLL_ENV: production
-  ${{ if eq(parameters['environment'], 'prod') }}:
-    AZURE_SUBSCRIPTION: $(PROD_AZURE_SUBSCRIPTION)
-    STORAGE_ACCOUNT_NAME: $(PROD_STORAGE_ACCOUNT_NAME)
-    PROFILE_CDN_NAME: $(PROD_PROFILE_CDN_NAME)
-    ENDPOINT_NAME: $(PROD_ENDPOINT_NAME)
-    RESOURCE_GROUP_NAME: $(PROD_RESOURCE_GROUP_NAME)
-    JEKYLL_ENV: production
+  AZURE_SUBSCRIPTION: $(PROD_AZURE_SUBSCRIPTION)
+  STORAGE_ACCOUNT_NAME: $(PROD_STORAGE_ACCOUNT_NAME)
+  PROFILE_CDN_NAME: $(PROD_PROFILE_CDN_NAME)
+  ENDPOINT_NAME: $(PROD_ENDPOINT_NAME)
+  RESOURCE_GROUP_NAME: $(PROD_RESOURCE_GROUP_NAME)
+  JEKYLL_ENV: production
+  PIPELINE_TYPE: $(Build.Reason)
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -45,7 +38,7 @@ steps:
 
 - script: |
     bundle install
-    JEKYLL_ENV=production bundle exec jekyll build --config _config.yml,_config_production.yml
+    JEKYLL_ENV=production PIPELINE_TYPE=$(PIPELINE_TYPE) bundle exec jekyll build --config _config.yml,_config_production.yml
   displayName: 'Build by Jekyll'
 
 - script: |
@@ -54,18 +47,42 @@ steps:
     echo BLOB_CONTAINER_NAME: $(BLOB_CONTAINER_NAME) 
   displayName: 'Check Site'
 
+# SYNC STORAGE AT EVERY COMMIT, so WITHOUT Enti&Servizi (PIPELINE_TYPE!=Schedule)
 - task: AzureCLI@1
-  displayName: 'Sync Storage'
+  displayName: 'Sync Storage NOT SCHEDULED'
+  condition: ne(variables['Build.Reason'], 'Schedule')
+  inputs:
+    azureSubscription: '$(AZURE_SUBSCRIPTION)'
+    scriptLocation: inlineScript
+    inlineScript: |
+      az storage blob sync --container $(BLOB_CONTAINER_NAME) --account-name $(STORAGE_ACCOUNT_NAME) -s "$(Build.SourcesDirectory)/_site" --exclude-path "assets/json/enti-list-webview.json;assets/json/enti-list-searchable.json;assets/json/enti-list-numbers.json;/app-content/enti-servizi.html;enti/" --exclude-pattern "assets/entijson/*.json"
+
+# SYNC STORAGE AT EVERY SCHEDULE, with Enti&Servizi (PIPELINE_TYPE==Schedule)
+- task: AzureCLI@1
+  displayName: 'Sync Storage ALL'
+  condition: eq(variables['Build.Reason'], 'Schedule')
   inputs:
     azureSubscription: '$(AZURE_SUBSCRIPTION)'
     scriptLocation: inlineScript
     inlineScript: |
       az storage blob sync --container $(BLOB_CONTAINER_NAME) --account-name $(STORAGE_ACCOUNT_NAME) -s "$(Build.SourcesDirectory)/_site"
 
+# PURGE CDN AT EVERY COMMIT, so globally
 - task: AzureCLI@1
-  displayName: 'Purge CDN'
+  displayName: 'Purge CDN NOT SCHEDULED'
+  condition: ne(variables['Build.Reason'], 'Schedule')
   inputs:
     azureSubscription: '$(AZURE_SUBSCRIPTION)'
     scriptLocation: inlineScript
     inlineScript: |
       az cdn endpoint purge -g $(RESOURCE_GROUP_NAME) -n $(ENDPOINT_NAME) --profile-name $(PROFILE_CDN_NAME) --content-paths "/*"
+
+# PURGE CDN AT SCHEDULE, so only with Ent&Servizi paths
+- task: AzureCLI@1
+  displayName: 'Purge CDN SCHEDULED'
+  condition: eq(variables['Build.Reason'], 'Schedule')
+  inputs:
+    azureSubscription: '$(AZURE_SUBSCRIPTION)'
+    scriptLocation: inlineScript
+    inlineScript: |
+      az cdn endpoint purge -g $(RESOURCE_GROUP_NAME) -n $(ENDPOINT_NAME) --profile-name $(PROFILE_CDN_NAME) --content-paths "/assets/entijson/*" "/assets/json/*" "/app-content/*" "/enti/*"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _data/cobadgeServices.json
 _data/mediumposts.json
 _data/enti-servizi.json
 assets/entijson/*.json
+assets/json/enti-list-numbers.json

--- a/_includes/home/section-14.html
+++ b/_includes/home/section-14.html
@@ -9,12 +9,12 @@
             <div class="row">
                 <div class="col-6 pl-4">
                     <img src="{{site.imagesurl}}/assets/img/municipality.svg" alt="Enti" class="my-2">
-                    <div class="h2 text-white my-2">{{entinum | friendly_number}}</div>
+                    <div class="h2 text-white my-2" id="home-enti-num"></div>
                     <div class="text-desc font-weight-bold">Enti attivi su IO</div>
                 </div>
                 <div class="col-6 pr-4">
                     <img src="{{site.imagesurl}}/assets/img/services.svg" alt="Servizi" class="my-2">
-                    <div class="h2 text-white my-2">{{servnum | friendly_number}}</div>
+                    <div class="h2 text-white my-2" id="home-servizi-num"></div>
                     <div class="text-desc font-weight-bold">Servizi disponibili</div>
                 </div>
             </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -14,7 +14,9 @@ contributors - MIT license @link https://github.com/FezVrasta/popper.js
 
 <script src="{{ '/assets/js/vendor/bootstrap-italia.min.js?' | append: buildTime | relative_url }}"></script>
 
-{%if page.layout == 'home' %} {% comment %} Parallax 3.1.0 - Copyright © 2014
+{%if page.layout == 'home' %} 
+<script src="{{ '/assets/js/home.js' }}"></script>
+{% comment %} Parallax 3.1.0 - Copyright © 2014
 Matthew Wagerfield - @wagerfield - MIT license @link
 https://github.com/wagerfield/parallax {% endcomment %}
 <script async src="{{ '/assets/js/vendor/parallax.min.js' }}"></script>

--- a/_plugins/generateEntiList.rb
+++ b/_plugins/generateEntiList.rb
@@ -5,6 +5,12 @@ THIS SCRIPT IS USEFUL TO GENERATE A NEW JSON WITH ENTI'S DATA
 require 'json'
 require 'down'
 
+# If the pipeline isn't scheduled, then break the flow
+if ENV['PIPELINE_TYPE']!='Schedule' && ENV['JEKYLL_ENV']=='production'
+    File.write('_data/enti-servizi.json', JSON.dump({"items":[]}))
+    return "+++++++ ENTI LIST GEN DISABLED +++++++"
+end
+
 downloadUrl = "https://assets.cdn.io.italia.it/services-webview/visible-services-extended.json"
 begin
     file =  Down.download(downloadUrl, open_timeout: 15)
@@ -61,6 +67,8 @@ def renderEntiList(file, site)
         scope = ""
         # ---
         item_new_values = {}
+        # ordering services by name
+        item["s"].sort_by! { |k| k["n"]}
         services_counter += item["s"].length()
         # for every service we use the markdownify filter
         item["s"].each_with_index do | service, index |

--- a/_plugins/generateEntiList.rb
+++ b/_plugins/generateEntiList.rb
@@ -108,10 +108,13 @@ def renderEntiList(file, site)
     # conversion of hash in array
     new_content["items"] = new_content["items"].values
 
+    numbers_info = {"enti" => new_content["entinum"], "services" => new_content["servnum"]}
+
     enti_searchable_sorted = enti_searchable.sort
 
     File.write('./assets/json/enti-list-webview.json', JSON.dump( new_content_webview.values.sort_by{ |hsh| hsh.values[0] } ))
     File.write('./assets/json/enti-list-searchable.json', JSON.dump(enti_searchable_sorted))
+    File.write('./assets/json/enti-list-numbers.json', JSON.dump(numbers_info))
     File.write('_data/enti-servizi.json', JSON.dump(new_content))
 end
 

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -1,0 +1,13 @@
+var INFOURL = "/assets/json/enti-list-numbers.json";
+
+$(window).on("load", function() {
+    $enti = $("#home-enti-num");
+    $services = $("#home-servizi-num");
+    $.get( INFOURL, function( data ) {
+        $enti.text(data.enti);
+        $services.text(data.services);
+      }, "json")
+      .fail(function() {
+        $enti.parent().parent().remove();
+      });
+});


### PR DESCRIPTION
### Goal
TO split deploy to separate a "normal deploy" with the scheduled one, to avoid the enti&servizi list generation at every commit.
After this PR we'll have two different scenarios.
Every commit: the site will build without enti&servizi stuffs and a global purge (cause it's impossible to exclude paths at purge).
Every commit scheduled at 12AM: the site will build with enti&servizi stuffs and synced only this part, the purge will done only at enti&servizi paths.

### What I done
- Modified the script (generateEntiList.rb) to use a specific ENV to break the ingestion of enti's json
- Modified devop script to set the specific ENV to "Schedule"/Not to inform the buil when the site is build by a cron task or not.
- Modified the home of the site to catch the sum of Enti & Servizi using a specific json instead a Jekyll collection
