### PR TITLE
[WEB 220] Donation Landing amendments

### DIFF
--- a/_data/faq-donazioni-ucraina.yml
+++ b/_data/faq-donazioni-ucraina.yml
@@ -12,7 +12,7 @@ it:
   - title: La donazione prevede dei costi di commissione? 
     body: "Se doni con carta di credito, debito o prepagata non hai costi di commissione."
   - title: Dopo la donazione, non ho ricevuto nessuna email con la ricevuta. Cosa posso fare?
-    body: "Se doni con l'app IO, ti invieremo un'email con la ricevuta della donazione. Se non la ricevi, guarda nella cartella spam e verifica che l'indirizzo che trovi nella sezione Profilo > I tuoi dati sia corretto. Ti consigliamo di conservare la ricevuta, insieme alla documentazione originale del versamento (come l'estratto conto della banca o della carta di credito) per fini fiscali."
+    body: "Se doni dall'app IO tramite un dispositivo Android, ti invieremo un'email con la ricevuta della donazione. Se non la ricevi, guarda nella cartella spam e verifica che l'indirizzo che trovi nella sezione Profilo > I tuoi dati sia corretto. Ti consigliamo di conservare la ricevuta, insieme alla documentazione originale del versamento (come l'estratto conto della banca o della carta di credito) per fini fiscali."
   - title: "Rappresento un'organizzazione umanitaria: posso partecipare all'iniziativa?"
     body: "Per avere informazioni su come partecipare all'iniziativa, scrivi un'email a [affari.istituzionali@pagopa.it](mailto:affari.istituzionali@pagopa.it)."
   - title: "Posso donare anche se non ho ancora installato l'app IO?"


### PR DESCRIPTION
As of the next app version, only those who donate with an Android device will receive a receipt.

The related FAQ has been amended.

Merge it only after the new iOS version is released.