### PR TITLE
[WEB-221] Donation FAQ amendments

### DIFF
--- a/_includes/donazioni-ucraina-page.html
+++ b/_includes/donazioni-ucraina-page.html
@@ -81,7 +81,7 @@
               <h3 class="h2 text-primary pb-4 pt-lg-4">
               <span class="d-block font-weight-normal">03</span>Completa la donazione
               </h3>
-            <p>Scegli uno dei metodi che hai salvato nel Portafoglio e premi “Paga”. Se doni con carte del circuito Visa, Maestro o Mastercard non hai costi di commissione. L'importo arriverà direttamente sul conto corrente dell'organizzazione e tu riceverai un’email con i dati utili ai fini delle agevolazioni fiscali.</p>
+            <p>Seleziona un metodo di pagamento e premi “Paga”. Se doni con carta di credito, debito o prepagata non hai costi di commissione. L'importo arriverà direttamente sul conto corrente dell'organizzazione.</p>
           </div>
          </div><!--/row-->
       </div><!--/container-->


### PR DESCRIPTION
As of the next app version, only those who donate with an Android device will receive a receipt, and iOS users will not be able to use a method in saved in their app wallet.

The related section in the landing page has been amended accordingly.

Merge it only after the new iOS version is released.