### PR TITLE
[#IOPAE-150] Update technical guide link

### DIFF
--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -47,7 +47,7 @@ it:
     cat: "2|Servizi Disponibili"
   - title: Come fanno gli Enti pubblici a portare i propri servizi su IO?
     body: "Tutti gli enti pubblici, nazionali e locali, possono già aggiungere i propri servizi liberamente su IO e potranno continuare a farlo dopo l’arrivo dell’app negli store nella primavera 2020.\ 
-    È facile e veloce: in [questa Guida](https://io.italia.it/assets/download/it/onboarding/220725_io_app_onboarding_istruzioni-v_1.1.pdf) forniamo tutte le informazioni per aiutare le Pubbliche Amministrazioni a cogliere questa opportunità in quattro semplici passaggi."
+    È facile e veloce: in [questa Guida](https://docs.pagopa.it/io-guida-tecnica/) forniamo tutte le informazioni per aiutare le Pubbliche Amministrazioni a cogliere questa opportunità in quattro semplici passaggi."
     cat: "4|Pubbliche Amministrazioni"
   - title: Perchè devo per forza avere SPID o CIE per usare la app?
     body: "IO è un canale grazie al quale puoi ricevere da tutti gli Enti pubblici messaggi che includono tue informazioni personali come, ad esempio, quelle legate al tuo lavoro, alla tua salute o ai pagamenti verso lo Stato.\ 

--- a/_includes/pubbliche-amministrazioni.html
+++ b/_includes/pubbliche-amministrazioni.html
@@ -116,7 +116,7 @@
 
           </p>
           <a
-            href="/assets/download/it/accordo-di-adesione-IO-2.4.zip"
+            href="https://docs.pagopa.it/io-guida-tecnica/setup-iniziale"
             class="btn btn-outline-white btn-icon text-left mt-auto w-100 justify-content-start"
           >
             <svg class="icon mr-2 cta">

--- a/it/pubbliche-amministrazioni.md
+++ b/it/pubbliche-amministrazioni.md
@@ -18,7 +18,7 @@ redirect_from:
   - /pubbliche-amministrazioni/partecipa.html
 intro_image: "/assets/img/intro-pa.svg"
 intro_primary_text: "consulta la guida"
-intro_primary_link: "/assets/download/it/onboarding/220725_io_app_onboarding_istruzioni-v_1.1.pdf"
+intro_primary_link: "https://docs.pagopa.it/io-guida-tecnica/"
 intro_primary_onclick: "ga('send', 'event', 'link', 'click', 'Guida Enti', 1)"
 intro_secondary_text: "Richiedi informazioni"
 intro_secondary_link: "mailto:onboarding@io.italia.it"


### PR DESCRIPTION
Remove link to the pdf onboarding guide due to an old contract reference.
Add link to new guide with new joining methods with better explanation.