### PR TITLE
[WEB-277] typo redirect_to in redirect.html layout

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no">
     <meta name="robots" content=" noindex, nofollow">
     <link rel="canonical" href="{{ site.url }}{{ page.url | replace:'index.html',''}}">
-    <meta http-equiv="refresh" content="0;url={{page.redirect_to}}">
+    <meta http-equiv="refresh" content="0;url={{page.redirect.to}}">
     <title>
         {%- if page.title -%}
         {{ page.title | smartify }} – {{ site.title[current_lang] | smartify }}


### PR DESCRIPTION
## Description
Fixed a typo (page.redirect_to -> page.redirect.to) inside the redirect.html layout file causing client-side redirects to malfunction

Fixes # [WEB-277](https://pagopa.atlassian.net/browse/WEB-277)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

[WEB-277]: https://pagopa.atlassian.net/browse/WEB-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ