### PR TITLE
Replace CDN with direct storage access to visible-services-extended.json

### DIFF
--- a/_plugins/generateEntiList.rb
+++ b/_plugins/generateEntiList.rb
@@ -11,7 +11,7 @@ if ENV['PIPELINE_TYPE']=='BatchedCI' && ENV['JEKYLL_ENV']=='production'
     return "+++++++ ENTI LIST GEN DISABLED +++++++"
 end
 
-downloadUrl = "https://assets.cdn.io.italia.it/services-webview/visible-services-extended.json"
+downloadUrl = "https://iopstcdnassets.blob.core.windows.net/services/services-webview/visible-services-extended.json"
 begin
     file =  Down.download(downloadUrl, open_timeout: 15)
 rescue


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
The visible-services-extended.json file gets truncated while downloading from the CDN. Unfortunately, this behavior isn't easily reproducible and happens just sometimes. Our attempt here is to bypass the CDN and access the storage directly.

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
