### PR TITLE
New educational pages for app users

### DIFF
--- a/it/nuova-sezione-pagamenti-istruzioni.md
+++ b/it/nuova-sezione-pagamenti-istruzioni.md
@@ -1,0 +1,80 @@
+---
+layout: internal
+title: Scopri la nuova sezione Pagamenti!
+lang: it
+ref: "nuova-sezione-pagamenti-istruzioni"
+permalink: /nuova-sezione-pagamenti-istruzioni/
+narrow: true
+noheight: true
+index: no-index
+---
+
+L’ultima versione dell’app IO include la nuova sezione Pagamenti, con l’obiettivo di mostrarti più facilmente le tue ricevute pagoPA e offrirti un’esperienza di pagamento ancora più intuitiva. **Per questo motivo, abbiamo rimosso alcuni metodi salvati nel tuo Portafoglio.**
+
+**Scopri le novità per:**
+
+- [Carte di debito o credito](#carte-di-debito-o-credito)
+- [BANCOMAT Pay®](#bancomat-pay)
+- [PayPal](#paypal)
+
+## Carte di debito o credito
+
+### Le carte scadute sono state rimosse
+
+Abbiamo rimosso eventuali carte scadute o non compatibili con i pagamenti online.
+
+### Aggiungi le tue carte
+
+Se vuoi usare la tua carta in app, aggiungila al tuo Portafoglio prima di fare un pagamento.
+
+Presto potrai anche pagare gli avvisi pagoPA senza dover per forza salvare la carta nel Portafoglio: può tornare utile, per esempio, se usi carte monouso o usa e getta.
+
+## BANCOMAT Pay®
+
+### Il tuo account BANCOMAT PAY® è stato rimosso
+
+Pagare con BANCOMAT Pay® è ora più semplice: non serve più salvarlo nel Portafoglio.
+
+### Come pagare con BANCOMAT PAY®
+
+1. In fase di pagamento, seleziona BANCOMAT Pay® dall’elenco dei metodi disponibili;
+2. quando richiesto, inserisci il numero di cellulare associato al tuo IBAN;
+3. autorizza il pagamento con l’app BANCOMAT Pay® o quella della tua banca.
+
+Per maggiori informazioni, [guarda il video tutorial](https://www.youtube.com/watch?v=mil4jEuaMo0){:target="\_blank"} o [leggi le domande frequenti](https://bancomat.it/it/privati/bancomat-pay){:target="\_blank"}.
+
+
+## PayPal
+
+### Il tuo account PayPal è stato rimosso
+
+Non preoccuparti: puoi continuare a usare PayPal per i tuoi pagamenti tramite pagoPA, scegliendo tra due nuove modalità descritte di seguito.
+
+### Scopri la nuova modalità “PayPal (anche in 3 rate)”
+
+**Nota: il metodo “PayPal (anche in 3 rate)” sarà disponibile a partire dal 25 luglio 2024.**
+
+Usa questa modalità se vuoi scegliere ad ogni pagamento quale carta o conto utilizzare. Puoi anche pagare in 3 rate senza interessi, secondo quanto previsto dai [Termini e Condizioni d’uso di Paga in 3 Rate - PayPal](https://www.paypal.com/it/webapps/mpp/campaigns/pay-in-3-full).
+
+Ecco come fare:
+1. In fase di pagamento, seleziona “PayPal (anche in 3 rate)” dall’elenco dei metodi disponibili;
+3. segui le indicazioni di PayPal per scegliere dove addebitare la spesa e decidere se pagare in 3 rate.
+
+
+### Preferisci pagare più velocemente? Aggiungi PayPal al Portafoglio
+
+**Nota: il metodo “PayPal pagamento veloce” non consente di pagare in 3 rate.**
+
+Scegli questo metodo se vuoi salvare il tuo conto PayPal nel Portafoglio di IO e pagare gli avvisi pagoPA più velocemente.
+
+Ecco come fare:
+1. vai nella sezione Portafoglio e seleziona “Aggiungi al Portafoglio”;
+2. seleziona “Metodi di pagamento”, poi “PayPal pagamento veloce”;
+3. scegli quale gestore autorizzare per i pagamenti futuri;
+4. segui le indicazioni di PayPal e scegli su quale carta o conto bancario addebitare le spese future.
+
+In questo modo i pagamenti saranno autorizzati più velocemente: non ti verrà chiesto né di scegliere il gestore del pagamento né su quale carta o conto bancario addebitare la spesa.
+
+Se vuoi usare un altro gestore, aggiungi nuovamente il metodo al tuo Portafoglio.
+
+Per maggiori informazioni, [visita il sito PayPal](https://www.paypal.com/it/cshelp/article/che-cos%C3%A8-un-pagamento-automatico-e-come-faccio-ad-aggiornarne-o-annullarne-uno-help240){:target="\_blank"}.

--- a/it/nuova-sezione-pagamenti-legacy.md
+++ b/it/nuova-sezione-pagamenti-legacy.md
@@ -1,0 +1,88 @@
+---
+layout: internal
+title: Aggiorna l’app e scopri la nuova sezione Pagamenti!
+lang: it
+ref: "nuova-sezione-pagamenti-legacy"
+permalink: /nuova-sezione-pagamenti-legacy/
+narrow: true
+noheight: true
+index: no-index
+---
+
+È disponibile una nuova versione dell’app IO, che include la nuova sezione Pagamenti, con l’obiettivo di mostrarti più facilmente le tue ricevute pagoPA e offrirti un’esperienza di pagamento ancora più intuitiva. **Per questo motivo, rimuoveremo alcuni metodi salvati nel tuo Portafoglio.**
+
+**Scopri le novità per:**
+
+- [Carte di debito o credito](#carte-di-debito-o-credito)
+- [BANCOMAT Pay®](#bancomat-pay)
+- [PayPal](#paypal)
+
+## Carte di debito o credito
+
+### Le carte scadute verranno rimosse
+
+Nella nuova versione dell’app non ci saranno più eventuali carte scadute o non compatibili con i pagamenti online.
+
+### Aggiorna l’app e aggiungi le tue carte
+
+Ecco come fare:
+1. aggiorna IO all'ultima versione disponibile per usare l'app con tutte le nuove funzionalità;
+2. se vuoi usare la tua carta in app, aggiungila al tuo Portafoglio prima di fare un pagamento.
+
+Presto potrai anche pagare gli avvisi pagoPA senza dover per forza salvare la carta nel Portafoglio: può tornare utile, per esempio, se usi carte monouso o usa e getta.
+
+## BANCOMAT Pay®
+
+### Il tuo account BANCOMAT PAY® verrà rimosso
+
+Nella nuova versione dell’app il tuo account BANCOMAT Pay® non sarà più presente nel Portafoglio. 
+
+Non preoccuparti: puoi continuare a usare BANCOMAT Pay® per i tuoi pagamenti tramite pagoPA.
+
+### Aggiorna l’app e scopri come pagare con BANCOMAT PAY®
+
+1. Aggiorna IO all'ultima versione disponibile per usare l'app con tutte le nuove funzionalità;
+2. in fase di pagamento, seleziona BANCOMAT Pay® dall’elenco dei metodi disponibili;
+3. quando richiesto, inserisci il numero di cellulare associato al tuo IBAN;
+4. autorizza il pagamento con l’app BANCOMAT Pay® o quella della tua banca.
+
+Per maggiori informazioni, [guarda il video tutorial](https://www.youtube.com/watch?v=mil4jEuaMo0){:target="\_blank"} o [leggi le domande frequenti](https://bancomat.it/it/privati/bancomat-pay){:target="\_blank"}.
+
+
+## PayPal
+
+### Il tuo account PayPal verrà rimosso
+
+Nella nuova versione dell’app il tuo account PayPal non sarà più presente nel Portafoglio.
+Non preoccuparti: puoi continuare a usare PayPal per i tuoi pagamenti tramite pagoPA, scegliendo tra due nuove modalità descritte di seguito.
+
+### Scopri la nuova modalità “PayPal (anche in 3 rate)”
+
+**Nota: il metodo “PayPal (anche in 3 rate)” sarà disponibile a partire dal 25 luglio 2024.**
+
+Usa questa modalità se vuoi scegliere ad ogni pagamento quale carta o conto utilizzare. Puoi anche pagare in 3 rate senza interessi, secondo quanto previsto dai [Termini e Condizioni d’uso di Paga in 3 Rate - PayPal](https://www.paypal.com/it/webapps/mpp/campaigns/pay-in-3-full).
+
+Ecco come fare:
+1. aggiorna IO all'ultima versione disponibile per usare l'app con tutte le nuove funzionalità;
+2. in fase di pagamento, seleziona “PayPal (anche in 3 rate)” dall’elenco dei metodi disponibili;
+3. segui le indicazioni di PayPal per scegliere dove addebitare la spesa e decidere se pagare in 3 rate.
+
+
+### Preferisci pagare più velocemente? Aggiungi PayPal al Portafoglio
+
+**Nota: il metodo “PayPal pagamento veloce” non consente di pagare in 3 rate.**
+
+Scegli questo metodo se vuoi salvare il tuo conto PayPal nel Portafoglio di IO e pagare gli avvisi pagoPA più velocemente.
+
+Ecco come fare:
+1. aggiorna IO all'ultima versione disponibile per usare l'app con tutte le nuove funzionalità;
+2. vai nella sezione Portafoglio e seleziona “Aggiungi al Portafoglio”;
+3. seleziona “Metodi di pagamento”, poi “PayPal pagamento veloce”;
+4. scegli quale gestore autorizzare per i pagamenti futuri;
+5. segui le indicazioni di PayPal e scegli su quale carta o conto bancario addebitare le spese future.
+
+In questo modo i pagamenti saranno autorizzati più velocemente: non ti verrà chiesto né di scegliere il gestore del pagamento né su quale carta o conto bancario addebitare la spesa.
+
+Se vuoi usare un altro gestore, aggiungi nuovamente il metodo al tuo Portafoglio.
+
+Per maggiori informazioni, [visita il sito PayPal](https://www.paypal.com/it/cshelp/article/che-cos%C3%A8-un-pagamento-automatico-e-come-faccio-ad-aggiornarne-o-annullarne-uno-help240){:target="\_blank"}.


### PR DESCRIPTION
These pages help users understand the changes related to the payment feature. Each page is intended for a different audience: users with a deprecated app and users with an updated app. Users will be engaged by using, respectively, a banner in the legacy wallet page and in the new payments page