### PR TITLE
Update ruby version for deploy pipeline

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -29,7 +29,7 @@ pool:
 steps:
   - task: UseRubyVersion@0
     inputs:
-      versionSpec: "3.2.8"
+      versionSpec: "3.2.9"
 
   - script: |
       gem install jekyll bundler


### PR DESCRIPTION
Update ruby version for the deploy pipeline because minimum ruby version is `3.2.9` for Azure dev ops.