### PR TITLE
Update ruby version for deploy pipeline with any patch

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -29,7 +29,7 @@ pool:
 steps:
   - task: UseRubyVersion@0
     inputs:
-      versionSpec: "3.2.9"
+      versionSpec: "3.2"
 
   - script: |
       gem install jekyll bundler


### PR DESCRIPTION
Remove the exact ruby version using any minor for ruby `3.2` in deploy pipeline
BLOCKED: we prefer have an alert any minor update for check the progress on the deprecation fase of this repo.