### PR TITLE
Update tos prev version links

### DIFF
--- a/it/tos/5.1.md
+++ b/it/tos/5.1.md
@@ -3,7 +3,7 @@ title: Informativa privacy e Termini e condizioni d’uso
 subtitle:
 layout: self
 ref: app-tos-privacy
-permalink: /app-content/tos_privacy.html
+permalink: /app-content/tos_privacy_5.1.html
 vers: '5.1'
 updated: 10 dicembre 2024
 assets:

--- a/it/tos/5.2.md
+++ b/it/tos/5.2.md
@@ -3,7 +3,7 @@ title: Informativa privacy e Termini e condizioni d’uso
 subtitle:
 layout: self
 ref: app-tos-privacy
-permalink: /app-content/tos_privacy.html
+permalink: /app-content/tos_privacy_5.2.html
 vers: '5.2'
 updated: 6 maggio 2025
 assets:


### PR DESCRIPTION
Sser couldn't to navigate to last two ToS previous version. FIxing the link on top of the file used by build route