### PR TITLE
IOPLT-1793 - Update AZ DevOps CDN purge commands for AFD Standard compatibility

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -85,4 +85,4 @@ steps:
       azureSubscription: "$(AZURE_SUBSCRIPTION)"
       scriptLocation: inlineScript
       inlineScript: |
-        az afd endpoint purge -g $(RESOURCE_GROUP_NAME) ---endpoint-name $(ENDPOINT_NAME) --profile-name $(PROFILE_CDN_NAME) --content-paths "/assets/entijson/*" "/assets/json/*" "/app-content/*" "/enti/*"
+        az afd endpoint purge -g $(RESOURCE_GROUP_NAME) --endpoint-name $(ENDPOINT_NAME) --profile-name $(PROFILE_CDN_NAME) --content-paths "/assets/entijson/*" "/assets/json/*" "/app-content/*" "/enti/*"

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -75,7 +75,7 @@ steps:
       azureSubscription: "$(AZURE_SUBSCRIPTION)"
       scriptLocation: inlineScript
       inlineScript: |
-        az cdn endpoint purge -g $(RESOURCE_GROUP_NAME) -n $(ENDPOINT_NAME) --profile-name $(PROFILE_CDN_NAME) --content-paths "/*"
+        az afd endpoint purge -g $(RESOURCE_GROUP_NAME) --endpoint-name $(ENDPOINT_NAME) --profile-name $(PROFILE_CDN_NAME) --content-paths "/*"
 
   # PURGE CDN AT SCHEDULE, so only with Ent&Servizi paths
   - task: AzureCLI@1
@@ -85,4 +85,4 @@ steps:
       azureSubscription: "$(AZURE_SUBSCRIPTION)"
       scriptLocation: inlineScript
       inlineScript: |
-        az cdn endpoint purge -g $(RESOURCE_GROUP_NAME) -n $(ENDPOINT_NAME) --profile-name $(PROFILE_CDN_NAME) --content-paths "/assets/entijson/*" "/assets/json/*" "/app-content/*" "/enti/*"
+        az afd endpoint purge -g $(RESOURCE_GROUP_NAME) ---endpoint-name $(ENDPOINT_NAME) --profile-name $(PROFILE_CDN_NAME) --content-paths "/assets/entijson/*" "/assets/json/*" "/app-content/*" "/enti/*"


### PR DESCRIPTION
Update the purge commands for the CDN on the deploy pipeline to make them compatible with AFD Standard